### PR TITLE
[swap] add auto accept token while calling swap functions

### DIFF
--- a/src/modules/TokenSwapRouter.move
+++ b/src/modules/TokenSwapRouter.move
@@ -35,12 +35,9 @@ module TokenSwapRouter {
     ///
     /// Swap token auto accept
     ///
-    public fun swap_pair_token_auto_accept<X: store, Y: store>(signer: &signer) {
-        if (!Account::is_accepts_token<X>(Signer::address_of(signer))) {
-            Account::do_accept_token<X>(signer);
-        };
-        if (!Account::is_accepts_token<Y>(Signer::address_of(signer))) {
-            Account::do_accept_token<Y>(signer);
+    public fun swap_pair_token_auto_accept<Token: store>(signer: &signer) {
+        if (!Account::is_accepts_token<Token>(Signer::address_of(signer))) {
+            Account::do_accept_token<Token>(signer);
         };
     }
 
@@ -193,7 +190,7 @@ module TokenSwapRouter {
         amount_y_out_min: u128,
     ) {
         // auto accept
-        swap_pair_token_auto_accept<X, Y>(signer);
+        swap_pair_token_auto_accept<Y>(signer);
 
         let order = TokenSwap::compare_token<X, Y>();
         assert(order != 0, ERROR_ROUTER_INVALID_TOKEN_PAIR);
@@ -219,7 +216,7 @@ module TokenSwapRouter {
         amount_y_out: u128,
     ) {
         // auto accept
-        swap_pair_token_auto_accept<X, Y>(signer);
+        swap_pair_token_auto_accept<X>(signer);
 
         let order = TokenSwap::compare_token<X, Y>();
         assert(order != 0, ERROR_ROUTER_INVALID_TOKEN_PAIR);

--- a/src/modules/TokenSwapRouter.move
+++ b/src/modules/TokenSwapRouter.move
@@ -33,6 +33,18 @@ module TokenSwapRouter {
     }
 
     ///
+    /// Swap token auto accept
+    ///
+    public fun swap_pair_token_auto_accept<X: store, Y: store>(signer: &signer) {
+        if (!Account::is_accepts_token<X>(Signer::address_of(signer))) {
+            Account::do_accept_token<X>(signer);
+        };
+        if (!Account::is_accepts_token<Y>(Signer::address_of(signer))) {
+            Account::do_accept_token<Y>(signer);
+        };
+    }
+
+    ///
     /// Register swap pair by comparing sort
     ///
     public fun register_swap_pair<X: store, Y: store>(account: &signer) {
@@ -180,6 +192,9 @@ module TokenSwapRouter {
         amount_x_in: u128,
         amount_y_out_min: u128,
     ) {
+        // auto accept
+        swap_pair_token_auto_accept<X, Y>(signer);
+
         let order = TokenSwap::compare_token<X, Y>();
         assert(order != 0, ERROR_ROUTER_INVALID_TOKEN_PAIR);
         // calculate actual y out
@@ -203,10 +218,14 @@ module TokenSwapRouter {
         amount_x_in_max: u128,
         amount_y_out: u128,
     ) {
+        // auto accept
+        swap_pair_token_auto_accept<X, Y>(signer);
+
         let order = TokenSwap::compare_token<X, Y>();
         assert(order != 0, ERROR_ROUTER_INVALID_TOKEN_PAIR);
         // calculate actual y out
         let (reserve_x, reserve_y) = get_reserves<X, Y>();
+
         let x_in = get_amount_in(amount_y_out, reserve_x, reserve_y);
         assert(x_in <= amount_x_in_max, ERROR_ROUTER_X_IN_OVER_LIMIT_MAX);
         // do actual swap

--- a/tests/testsuite/test/swap_auto_accept.move
+++ b/tests/testsuite/test/swap_auto_accept.move
@@ -1,0 +1,97 @@
+//! account: alice, 10000000000000 0x1::STC::STC
+//! account: bob, 10000000000000 0x1::STC::STC
+//! account: admin, 0x81144d60492982a45ba93fba47cae988, 10000000000000 0x1::STC::STC
+//! account: liquidier, 10000000000000 0x1::STC::STC
+//! account: exchanger
+
+//! sender: alice
+address alice = {{alice}};
+module alice::TokenMock {
+    // mock Usdx token
+    struct Usdx has copy, drop, store { }
+}
+
+//! new-transaction
+//! sender: admin
+address alice = {{alice}};
+script {
+    use alice::TokenMock::{Usdx};
+    use 0x81144d60492982a45ba93fba47cae988::TokenSwap;
+    use 0x1::STC::STC;
+    fun register_token_pair(signer: signer) {
+        //token pair register must be swap admin account
+        TokenSwap::register_swap_pair<STC, Usdx>(&signer);
+        assert(TokenSwap::swap_pair_exists<STC, Usdx>(), 111);
+    }
+}
+
+//! new-transaction
+//! sender: alice
+address alice = {{alice}};
+script {
+    use alice::TokenMock::{Usdx};
+    use 0x81144d60492982a45ba93fba47cae988::TokenSwapRouter;
+    use 0x1::Account;
+    use 0x1::Token;
+    use 0x1::Math;
+    use 0x1::STC::STC;
+
+    // Deposit to swap pool
+    fun main(signer: signer) {
+        let precision: u8 = 9; //STC precision is also 9.
+
+        let scaling_factor = Math::pow(10, (precision as u64));// STC/Usdx = 1:5
+        let stc_amount: u128 = 1000000 * scaling_factor;
+        let usdx_amount: u128 = 1000000 * scaling_factor;
+
+        // Register first
+        Token::register_token<Usdx>(&signer, precision);
+        Account::do_accept_token<Usdx>(&signer);
+
+        let usdx_token = Token::mint<Usdx>(&signer, usdx_amount);
+        Account::deposit_to_self(&signer, usdx_token);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // Add liquidity, STC/Usdx = 1:1
+        let amount_stc_desired: u128 = 10000 * scaling_factor;
+        let amount_usdx_desired: u128 = 10000 * scaling_factor;
+        let amount_stc_min: u128 = stc_amount;
+        let amount_usdx_min: u128 = usdx_amount;
+        TokenSwapRouter::add_liquidity<STC, Usdx>(
+            &signer, amount_stc_desired, amount_usdx_desired, amount_stc_min, amount_usdx_min);
+
+        // check liquidity
+        let total_liquidity: u128 = TokenSwapRouter::total_liquidity<STC, Usdx>();
+        assert(total_liquidity > 0, 10000);
+
+        // check reverse
+        let (reserve_x, reserve_y) = TokenSwapRouter::get_reserves<STC, Usdx>();
+        assert(reserve_x >= amount_stc_desired, 10001);
+        assert(reserve_y >= amount_usdx_desired, 10001);
+   }
+}
+
+
+//! new-transaction
+//! sender: bob
+address bob = {{bob}};
+address alice = {{alice}};
+script {
+    use alice::TokenMock::Usdx;
+    use 0x1::STC::STC;
+    use 0x1::Account;
+    use 0x1::Signer;
+    use 0x1::Debug;
+    use 0x81144d60492982a45ba93fba47cae988::TokenSwapRouter;
+    use 0x81144d60492982a45ba93fba47cae988::TokenSwap;
+
+    fun main(signer: signer) {
+        let (reserve_x, reserve_y) = TokenSwap::get_reserves<STC, Usdx>();
+        Debug::print<u128>(&reserve_x);
+        Debug::print<u128>(&reserve_y);
+        TokenSwapRouter::swap_exact_token_for_token<STC, Usdx>(&signer, 10, 0);
+        let balance = Account::balance<Usdx>(Signer::address_of(&signer));
+        assert(balance > 0, 10002);
+    }
+}
+

--- a/tests/testsuite/test/swap_auto_accept.move
+++ b/tests/testsuite/test/swap_auto_accept.move
@@ -89,9 +89,13 @@ script {
         let (reserve_x, reserve_y) = TokenSwap::get_reserves<STC, Usdx>();
         Debug::print<u128>(&reserve_x);
         Debug::print<u128>(&reserve_y);
-        TokenSwapRouter::swap_exact_token_for_token<STC, Usdx>(&signer, 10, 0);
+        TokenSwapRouter::swap_exact_token_for_token<STC, Usdx>(&signer, 100, 0);
         let balance = Account::balance<Usdx>(Signer::address_of(&signer));
         assert(balance > 0, 10002);
+
+        TokenSwapRouter::swap_token_for_exact_token<STC, Usdx>(&signer, 10000000, 10000);
+        let balance = Account::balance<STC>(Signer::address_of(&signer));
+        assert(balance > 0, 10003);
     }
 }
 


### PR DESCRIPTION
在调用置换函数用代币A置换代币B时，若用户没有accept代币B，则在该函数中自动accept 代币B